### PR TITLE
Fix lambdaconf link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ false : Bool
 Good-bye.
 ~~~
 
-As you can see, glambda uses [de Bruijn indices][1] to track variable binding.
+As you can see, glambda uses [de Bruijn indices][3] to track variable binding.
 In the actual output (if your console supports it), the binders (`#`) and
 usage sites (`#0`, `#1`) are colored so that humans can easily tell which
 variable is used where.
 
-[1]: https://en.wikipedia.org/wiki/De_Bruijn_index
+[3]: https://en.wikipedia.org/wiki/De_Bruijn_index
 
 You can also see above that the input to glambda must be fully annotated;
 glambda does *not* do type inference. However, note that types on binders


### PR DESCRIPTION
The lambdaconf link was getting overwritten by the link to de bruijn index article on wikipedia, causing a bit of confusion when I clicked on it :)
