### PR TITLE
remove Error dependency, merged Monad.hs from master

### DIFF
--- a/glambda.cabal
+++ b/glambda.cabal
@@ -26,8 +26,7 @@ source-repository this
 
 library
   build-depends:      base == 4.*
-                    , ansi-wl-pprint >= 0.6.7.1
-                    
+                    , ansi-wl-pprint >= 0.6.7.1                   
                     , mtl >= 2.1.3.1
                     , transformers >= 0.4.0.0
                     , containers >= 0.5
@@ -81,7 +80,7 @@ test-suite tests
                     , glambda
                     , template-haskell
                     , ansi-wl-pprint >= 0.6.7.1
-                    , errors >= 1.4.6 && < 2.0
+                    , transformers >= 0.4.0.0
                     , mtl >= 2.1.3.1
                     , parsec >= 3.1
                     , tasty >= 0.8.1

--- a/glambda.cabal
+++ b/glambda.cabal
@@ -27,8 +27,9 @@ source-repository this
 library
   build-depends:      base == 4.*
                     , ansi-wl-pprint >= 0.6.7.1
-                    , errors >= 1.4.6 && < 2.0
+                    
                     , mtl >= 2.1.3.1
+                    , transformers >= 0.4.0.0
                     , containers >= 0.5
                     , parsec >= 3.1
                     , haskeline >= 0.7.1.1

--- a/src/Language/Glambda/Monad.hs
+++ b/src/Language/Glambda/Monad.hs
@@ -33,9 +33,9 @@ import System.Console.Haskeline
 
 import Text.PrettyPrint.ANSI.Leijen
 
-import Control.Error
+import Control.Monad.Trans.Maybe
+import Control.Monad.Except
 import Control.Monad.Reader
-import Control.Monad.Error
 import Control.Monad.State
 import System.IO
 
@@ -49,7 +49,7 @@ newtype Glam a = Glam { unGlam :: MaybeT (StateT Globals (InputT IO)) a }
   deriving (Monad, Functor, Applicative, MonadState Globals, MonadIO)
 
 -- | Like the 'Glam' monad, but also supporting error messages via 'Doc's
-newtype GlamE a = GlamE { unGlamE :: EitherT Doc Glam a }
+newtype GlamE a = GlamE { unGlamE :: ExceptT Doc Glam a }
   deriving (Monad, Functor, Applicative, MonadError Doc)
 
 instance MonadReader Globals GlamE where
@@ -105,4 +105,4 @@ runGlam thing_inside
 -- | Run a 'GlamE' computation
 runGlamE :: GlamE a -> Glam (Either Doc a)
 runGlamE thing_inside
-  = runEitherT $ unGlamE thing_inside
+  = runExceptT $ unGlamE thing_inside

--- a/tests/Tests/Check.hs
+++ b/tests/Tests/Check.hs
@@ -13,11 +13,12 @@ import Language.Glambda.Eval
 import Language.Glambda.Globals
 import Language.Glambda.Util
 
-import Control.Error
+import Control.Monad.Trans.Except
 import Control.Monad.Reader
 
 import Text.PrettyPrint.ANSI.Leijen
 
+import Data.Maybe
 import Data.List as List
 import Control.Arrow as Arrow
 
@@ -52,7 +53,7 @@ checkTests :: TestTree
 checkTests = testGroup "Typechecker" $
   List.map (\(expr_str, m_result) ->
                testCase ("`" ++ expr_str ++ "'") $
-               (case flip runReader id_globals $ runEitherT $ do
+               (case flip runReader id_globals $ runExceptT $ do
                        uexp <- hoistEither $ Arrow.left text $ parseExp =<< lex expr_str
                        check uexp $ \sty exp -> return $
                          case m_result of
@@ -64,6 +65,9 @@ checkTests = testGroup "Typechecker" $
                   of
                   Left _  -> assertBool "unexpected failure" (isNothing m_result)
                   Right b -> b)) checkTestCases
+
+hoistEither :: Monad m => Either e a -> ExceptT e m a
+hoistEither = ExceptT . return
 
 id_globals :: Globals
 id_globals = extend "id_int" (SIntTy `SArr` SIntTy) (Lam (Var EZ)) emptyGlobals


### PR DESCRIPTION
Hi, 
I watched your LambdaConf lecture/workshop about GADTs yesterday and I thought it was great! but I did get this weird dependency error when trying to build branch ex3 (cabal output below). After googling around a little and not finding obvious solution, I just ported your changes from master (replacing Error Monad with Except) and that seems to have solved it. 

I'm sending that PR, just in case someone else runs into the same problem.. 


>cabal configure
Resolving dependencies...
Warning: solver failed to find a solution:
Could not resolve dependencies:
trying: glambda-1.0 (user goal)
next goal: errors (dependency of glambda-1.0)
Dependency tree exhaustively searched.
Trying configure anyway.
Configuring glambda-1.0...
cabal: Encountered missing dependencies:
errors >=1.4.6 && <2.0

