### PR TITLE
Tightened bounds for ansi-wl-pprint and mtl.

### DIFF
--- a/glambda.cabal
+++ b/glambda.cabal
@@ -26,8 +26,8 @@ source-repository this
 
 library
   build-depends:      base == 4.*
-                    , ansi-wl-pprint == 0.6.8.1
-                    , mtl == 2.2.2
+                    , ansi-wl-pprint <= 0.6.9
+                    , mtl >= 2.2.1
                     , transformers >= 0.4.0.0
                     , containers >= 0.5
                     , parsec >= 3.1

--- a/glambda.cabal
+++ b/glambda.cabal
@@ -26,8 +26,8 @@ source-repository this
 
 library
   build-depends:      base == 4.*
-                    , ansi-wl-pprint >= 0.6.7.1
-                    , mtl >= 2.2.1
+                    , ansi-wl-pprint == 0.6.8.1
+                    , mtl == 2.2.2
                     , transformers >= 0.4.0.0
                     , containers >= 0.5
                     , parsec >= 3.1

--- a/src/Language/Glambda/Check.hs
+++ b/src/Language/Glambda/Check.hs
@@ -33,7 +33,7 @@ import Language.Glambda.Monad ( GlamE )
 import Text.PrettyPrint.ANSI.Leijen
 
 import Control.Monad.Reader
-import Control.Monad.Error
+import Control.Monad.Except
 
 -- | Abort with a type error in the given expression
 typeError :: MonadError Doc m => UExp -> Doc -> m a

--- a/src/Language/Glambda/Globals.hs
+++ b/src/Language/Glambda/Globals.hs
@@ -21,7 +21,7 @@ import Language.Glambda.Type
 
 import Text.PrettyPrint.ANSI.Leijen
 
-import Control.Monad.Error
+import Control.Monad.Except
 
 import Data.Map as Map
 

--- a/src/Language/Glambda/Monad.hs
+++ b/src/Language/Glambda/Monad.hs
@@ -33,6 +33,7 @@ import System.Console.Haskeline
 
 import Text.PrettyPrint.ANSI.Leijen
 
+import Control.Monad (mzero)
 import Control.Monad.Trans.Maybe
 import Control.Monad.Except
 import Control.Monad.Reader

--- a/src/Language/Glambda/Parse.hs
+++ b/src/Language/Glambda/Parse.hs
@@ -39,6 +39,7 @@ import Data.List as List
 import Control.Applicative
 import Control.Arrow as Arrow ( left )
 import Control.Monad.Reader
+import Control.Monad (guard)
 
 -- | Parse a sequence of semicolon-separated statements, aborting with
 -- an error upon failure


### PR DESCRIPTION
Since [ansi-wl-pprint](https://hackage.haskell.org/package/ansi-wl-pprint) went into maintenance mode a [bridge library](https://hackage.haskell.org/package/prettyprinter-compat-ansi-wl-pprint) was created to transition to [Prettyprinter](https://hackage.haskell.org/package/prettyprinter-1.7.1/docs/Prettyprinter.html). However, in so doing it changed the return type expected from the `Pretty` typeclass. It was changed from a `Doc` which expected no type arguments to one that did. This then broke the `Pretty` instances present in multiple files in `glambda`.

I fixed this by restricting the package bounds to the original version of `ansl-wl-pprint` used when `glambda` was written. I also had to change the bounds of `mtl` because `Control.Monad.Error` was used which has been replaced with `Control.Monad.Except`.