### PR TITLE
fix: add an bound for ansi-wl-pprint in the ex3 branch

### DIFF
--- a/glambda.cabal
+++ b/glambda.cabal
@@ -26,7 +26,7 @@ source-repository this
 
 library
   build-depends:      base == 4.*
-                    , ansi-wl-pprint >= 0.6.7.1                   
+                    , ansi-wl-pprint <= 0.6.9
                     , mtl >= 2.1.3.1
                     , transformers >= 0.4.0.0
                     , containers >= 0.5


### PR DESCRIPTION
Noticed this branch needs the same fix while working through the material. Roughly the same fix as #9 but for the ex3 branch - thanks @JHaugh4! - for some reason just adding an upper bound for ansi-wl-pprint seems to be enough to make cabal build work.

Also thanks for this awesome project!