### PR TITLE
Porting to prettyprinter

### DIFF
--- a/glambda.cabal
+++ b/glambda.cabal
@@ -26,13 +26,15 @@ source-repository this
 
 library
   build-depends:      base == 4.*
-                    , ansi-wl-pprint <= 0.6.9
+                    , prettyprinter >= 1.7.0
+                    , prettyprinter-ansi-terminal >= 1.1.0
                     , mtl >= 2.2.1
                     , transformers >= 0.4.0.0
                     , containers >= 0.5
                     , parsec >= 3.1
                     , haskeline >= 0.7.1.1
                     , directory >= 1.2.0.1
+                    , text >= 2.1.1
 
 
   exposed-modules:    Language.Glambda.Repl
@@ -79,7 +81,8 @@ test-suite tests
   build-depends:      base == 4.*
                     , glambda
                     , template-haskell
-                    , ansi-wl-pprint >= 0.6.7.1
+                    , prettyprinter >= 1.7.0
+                    , prettyprinter-ansi-terminal >= 1.1.0
                     , mtl >= 2.2.1
                     , transformers >= 0.4.0.0
                     , parsec >= 3.1

--- a/src/Language/Glambda/Exp.hs
+++ b/src/Language/Glambda/Exp.hs
@@ -23,7 +23,8 @@ import Language.Glambda.Token
 import Language.Glambda.Util
 import Language.Glambda.Type
 
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter (Pretty, pretty, Doc, nest)
+import Prettyprinter.Render.Terminal (AnsiStyle)
 
 -- | @Elem xs x@ is evidence that @x@ is in the list @xs@.
 -- @EZ :: Elem xs x@ is evidence that @x@ is the first element of @xs@.
@@ -90,14 +91,14 @@ eqExp _             _             = False
 ----------------------------------------------------
 -- Pretty-printing
 
-instance Pretty (Exp ctx ty) where
-  pretty = defaultPretty
+instance PrettyT (Exp ctx ty) where
+  prettyT = defaultPretty
 
 instance PrettyExp (Exp ctx ty) where
   prettyExp = pretty_exp
 
-instance GlamVal ty => Pretty (Val ty) where
-  pretty = defaultPretty
+instance GlamVal ty => PrettyT (Val ty) where
+  prettyT = defaultPretty
 
 instance GlamVal ty => PrettyExp (Val ty) where
   prettyExp coloring prec v = prettyExp coloring prec (val v)
@@ -105,18 +106,18 @@ instance GlamVal ty => PrettyExp (Val ty) where
 -- | Pretty-prints a 'Val'. This needs type information to know how to print.
 -- Pattern matching gives GHC enough information to be able to find the
 -- 'GlamVal' instance needed to construct the 'PrettyExp' instance.
-prettyVal :: Val t -> STy t -> Doc
-prettyVal val SIntTy       = pretty val
-prettyVal val SBoolTy      = pretty val
-prettyVal val (_ `SArr` _) = pretty val
+prettyVal :: Val t -> STy t -> Doc AnsiStyle
+prettyVal val SIntTy       = prettyT val
+prettyVal val SBoolTy      = prettyT val
+prettyVal val (_ `SArr` _) = prettyT val
 
-pretty_exp :: Coloring -> Prec -> Exp ctx ty -> Doc
+pretty_exp :: Coloring -> Prec -> Exp ctx ty -> Doc AnsiStyle
 pretty_exp c _    (Var n)          = prettyVar c (elemToInt n)
 pretty_exp c prec (Lam body)       = prettyLam c prec Nothing body
 pretty_exp c prec (App e1 e2)      = prettyApp c prec e1 e2
 pretty_exp c prec (Arith e1 op e2) = prettyArith c prec e1 op e2
 pretty_exp c prec (Cond e1 e2 e3)  = prettyIf c prec e1 e2 e3
 pretty_exp c prec (Fix e)          = prettyFix c prec e
-pretty_exp _ _    (IntE n)         = int n
-pretty_exp _ _    (BoolE True)     = text "true"
-pretty_exp _ _    (BoolE False)    = text "false"
+pretty_exp _ _    (IntE n)         = pretty n
+pretty_exp _ _    (BoolE True)     = pretty "true"
+pretty_exp _ _    (BoolE False)    = pretty "false"

--- a/src/Language/Glambda/Globals.hs
+++ b/src/Language/Glambda/Globals.hs
@@ -19,7 +19,8 @@ module Language.Glambda.Globals (
 import Language.Glambda.Exp
 import Language.Glambda.Type
 
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter (Doc, pretty, (<+>), squotes)
+import Prettyprinter.Render.Terminal (AnsiStyle)
 
 import Control.Monad.Except
 
@@ -45,7 +46,7 @@ extend var sty exp (Globals globals)
 
 -- | Lookup a global variable. Fails with 'throwError' if the variable
 -- is not bound.
-lookupGlobal :: MonadError Doc m
+lookupGlobal :: MonadError (Doc AnsiStyle) m
              => Globals -> String
              -> (forall ty. STy ty -> Exp '[] ty -> m r)
              -> m r
@@ -53,5 +54,5 @@ lookupGlobal (Globals globals) var k
   = case Map.lookup var globals of
       Just (EExp sty exp) -> k sty exp
       Nothing             -> throwError $
-                             text "Global variable not in scope:" <+>
-                               squotes (text var)
+                             pretty "Global variable not in scope:" <+>
+                               squotes (pretty var)

--- a/src/Language/Glambda/Parse.hs
+++ b/src/Language/Glambda/Parse.hs
@@ -32,7 +32,7 @@ import Text.Parsec.Prim as Parsec hiding ( parse )
 import Text.Parsec.Pos
 import Text.Parsec.Combinator
 
-import Text.PrettyPrint.ANSI.Leijen hiding ( (<$>) )
+import Prettyprinter (pretty, squotes, (<+>)) 
 
 import Data.List as List
 
@@ -167,7 +167,7 @@ tycon = do
   n <- tok' unName
   case readTyCon n of
     Nothing -> unexpected $ render $
-               text "type" <+> squotes (text n)
+               pretty "type" <+> squotes (pretty n)
     Just ty -> return ty
 
 add_op, mul_op, bool_op :: Parser (UExp -> UExp -> UExp)

--- a/src/Language/Glambda/Statement.hs
+++ b/src/Language/Glambda/Statement.hs
@@ -14,14 +14,15 @@
 module Language.Glambda.Statement ( Statement(..) ) where
 
 import Language.Glambda.Unchecked
+import Language.Glambda.Type (prettyT, PrettyT)
 
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter (Pretty, pretty, (<+>))
 
 -- | A statement can either be a bare expression, which will be evaluated,
 -- or an assignment to a global variable.
 data Statement = BareExp UExp
                | NewGlobal String UExp
 
-instance Pretty Statement where
-  pretty (BareExp exp)     = pretty exp
-  pretty (NewGlobal v exp) = text v <+> char '=' <+> pretty exp
+instance PrettyT Statement where
+  prettyT (BareExp exp)     = prettyT exp
+  prettyT (NewGlobal v exp) = pretty v <+> pretty '=' <+> prettyT exp

--- a/src/Language/Glambda/Unchecked.hs
+++ b/src/Language/Glambda/Unchecked.hs
@@ -17,7 +17,8 @@ import Language.Glambda.Type
 import Language.Glambda.Token
 import Language.Glambda.Util
 
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter (pretty, Doc)
+import Prettyprinter.Render.Terminal (AnsiStyle)
 
 -- | Unchecked expression
 data UExp
@@ -31,20 +32,20 @@ data UExp
   | UIntE Int
   | UBoolE Bool
 
-instance Pretty UExp where
-  pretty = defaultPretty
+instance PrettyT UExp where
+  prettyT = defaultPretty
 
 instance PrettyExp UExp where
   prettyExp = pretty_exp
 
-pretty_exp :: Coloring -> Prec -> UExp -> Doc
+pretty_exp :: Coloring -> Prec -> UExp -> Doc AnsiStyle
 pretty_exp c _    (UVar n)                     = prettyVar c n
-pretty_exp _ _    (UGlobal n)                  = text n
+pretty_exp _ _    (UGlobal n)                  = pretty n
 pretty_exp c prec (ULam ty body)               = prettyLam c prec (Just ty) body
 pretty_exp c prec (UApp e1 e2)                 = prettyApp c prec e1 e2
 pretty_exp c prec (UArith e1 (UArithOp op) e2) = prettyArith c prec e1 op e2
 pretty_exp c prec (UCond e1 e2 e3)             = prettyIf c prec e1 e2 e3
 pretty_exp c prec (UFix body)                  = prettyFix c prec body
-pretty_exp _ _    (UIntE n)                    = int n
-pretty_exp _ _    (UBoolE True)                = text "true"
-pretty_exp _ _    (UBoolE False)               = text "false"
+pretty_exp _ _    (UIntE n)                    = pretty n
+pretty_exp _ _    (UBoolE True)                = pretty "true"
+pretty_exp _ _    (UBoolE False)               = pretty "false"

--- a/src/Language/Glambda/Util.hs
+++ b/src/Language/Glambda/Util.hs
@@ -23,7 +23,10 @@ module Language.Glambda.Util (
   ) where
 
 import Text.Parsec
-import Text.PrettyPrint.ANSI.Leijen as Pretty
+import Prettyprinter (Pretty, pretty, Doc, SimpleDocStream, layoutPretty, defaultLayoutOptions, parens, hardline)
+import Prettyprinter.Render.String (renderShowS)
+import Prettyprinter.Render.Terminal (AnsiStyle, renderStrict)
+import Data.Text (unpack)
 
 import Data.Char
 import Data.List
@@ -44,7 +47,7 @@ ignore :: Functor f => f a -> f ()
 ignore = (() <$)
 
 instance Pretty ParseError where
-  pretty = text . show
+  pretty = pretty . show
 
 -- | More perspicuous synonym for operator precedence
 type Prec = Rational
@@ -54,21 +57,21 @@ topPrec :: Prec
 topPrec = 0
 
 -- | Convert a 'Doc' to a 'String'
-render :: Doc -> String
-render = flip displayS "" . toSimpleDoc
+render :: Doc AnsiStyle -> String
+render = unpack . renderStrict . toSimpleDoc
 
 -- | Convert a 'Doc' to a 'SimpleDoc' for further rendering
-toSimpleDoc :: Doc -> SimpleDoc
-toSimpleDoc = renderPretty 1.0 78
+toSimpleDoc :: Doc AnsiStyle -> SimpleDocStream AnsiStyle
+toSimpleDoc = layoutPretty defaultLayoutOptions
 
 -- | Enclose a 'Doc' in parens if the flag is 'True'
-maybeParens :: Bool -> Doc -> Doc
+maybeParens :: Bool -> Doc ann -> Doc ann
 maybeParens True  = parens
 maybeParens False = id
 
 -- | Synonym for 'Pretty.<$>'
-($$) :: Doc -> Doc -> Doc
-($$) = (Pretty.<$>)
+($$) :: Doc AnsiStyle -> Doc AnsiStyle -> Doc AnsiStyle
+a $$ b = a <> hardline <> b
 
 -- | (Inefficiently) strips whitespace from a string
 stripWhitespace :: String -> String

--- a/tests/Tests/Check.hs
+++ b/tests/Tests/Check.hs
@@ -16,7 +16,7 @@ import Language.Glambda.Util
 import Control.Monad.Trans.Except
 import Control.Monad.Reader
 
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter(pretty, unAnnotate)
 
 import Data.Maybe
 import Data.List as List
@@ -54,12 +54,12 @@ checkTests = testGroup "Typechecker" $
   List.map (\(expr_str, m_result) ->
                testCase ("`" ++ expr_str ++ "'")
                (case flip runReader id_globals $ runExceptT $ do
-                       uexp <- hoistEither $ Arrow.left text $ parseExp =<< lex expr_str
+                       uexp <- hoistEither $ Arrow.left pretty $ parseExp =<< lex expr_str
                        check uexp $ \sty exp -> return $
                          case m_result of
                            Just result
-                             -> (render (plain $ pretty exp), unrefineTy sty,
-                                 render (plain $ prettyVal (eval exp) sty))
+                             -> (render (unAnnotate $ prettyT exp), unrefineTy sty,
+                                 render (unAnnotate $ prettyVal (eval exp) sty))
                                  @?= result
                            _ -> assertFailure "unexpected type-check success"
                   of

--- a/tests/Tests/Parse.hs
+++ b/tests/Tests/Parse.hs
@@ -3,11 +3,12 @@ module Tests.Parse where
 import Language.Glambda.Lex
 import Language.Glambda.Parse
 import Language.Glambda.Util
+import Language.Glambda.Type
 import Tests.Util
 
 import Prelude hiding ( lex )
 
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter (unAnnotate)
 
 import Data.List as List
 
@@ -35,7 +36,7 @@ parseTests :: TestTree
 parseTests = testGroup "Parser"
   [ testGroup "Success" $
     List.map (\(str, out) -> testCase ("`" ++ str ++ "'") $
-              render (plain $ pretty (parseExp =<< lex str)) @?=
+              render (unAnnotate $ prettyT (parseExp =<< lex str)) @?=
                 ("Right " ++ out))
              parseTestCases
   , testGroup "Failure" $

--- a/tests/Tests/Util.hs
+++ b/tests/Tests/Util.hs
@@ -24,7 +24,7 @@ import Language.Glambda.Util
 import Test.Tasty
 import Test.Tasty.HUnit ( testCase, (@?), Assertion )
 
-import Text.PrettyPrint.ANSI.Leijen
+import Prettyprinter (Pretty, pretty, (<+>), squotes, semi)
 
 import Text.Parsec ( ParseError )
 
@@ -32,8 +32,8 @@ import Data.Function
 import Language.Haskell.TH
 
 prettyError :: Pretty a => a -> a -> String
-prettyError exp act = render $ text "Expected" <+> squotes (pretty exp) <> semi <+>
-                                text "got" <+> squotes (pretty act)
+prettyError exp act = render $ pretty "Expected" <+> squotes (pretty exp) <> semi <+>
+                                pretty "got" <+> squotes (pretty act)
 
 (@?=) :: (Eq a, Pretty a) => a -> a -> Assertion
 act @?= exp = (act == exp) @? prettyError exp act
@@ -50,5 +50,5 @@ $( do decs <- reifyInstances ''Eq [ConT ''ParseError]
         _  -> return [] )
 
 instance (Pretty a, Pretty b) => Pretty (Either a b) where
-  pretty (Left x)  = text "Left" <+> pretty x
-  pretty (Right x) = text "Right" <+> pretty x
+  pretty (Left x)  = pretty "Left" <+> pretty x
+  pretty (Right x) = pretty "Right" <+> pretty x


### PR DESCRIPTION
Totally unrequited, but I went ahead and ported glambda to use prettyprinter instead of ansi-wl-pprint. Use if you want ;)

It's a wee bit clumsy as I had to create an additional PrettyT class to move around the Doc ann/Doc AnsiTerminal issue, but it works.